### PR TITLE
Ezy fix

### DIFF
--- a/i dont know/Assets/PlayerCombat.cs
+++ b/i dont know/Assets/PlayerCombat.cs
@@ -24,8 +24,8 @@ public class PlayerCombat : MonoBehaviour
 
         foreach (Collider2D enemy in hitEnemies)
         {
-            print(GetComponent<GameObject>().name);
-            Destroy(enemy.GetComponent<GameObject>());
+            print(enemy.gameObject.name);
+            Destroy(enemy.gameObject);
         }
     }
 


### PR DESCRIPTION
i switched an uppercase g to a lowercase one and now the attacking system worked. this is because Unity does not recognize Gameobject as a component.